### PR TITLE
Preserve original file names

### DIFF
--- a/movie/scenarios.py
+++ b/movie/scenarios.py
@@ -1,6 +1,7 @@
+import re
+
 import colors
 import consolemenu
-import re
 
 from movie.utils import movie
 from movie.utils import notation
@@ -88,7 +89,6 @@ def select_and_process_streams(object: movie.Movie):
     if input_streams is not None:
         pu.println(f'\nStarting saving streams process\n')
         object.process_streams(input_streams)
-        object.remove_video()
 
     _function_end(pu)
 
@@ -113,7 +113,6 @@ def select_and_process_streams_with_language(object: movie.Movie):
 
         pu.println(f'\nStarting saving streams process\n')
         object.process_streams_with_language(streams_languages)
-        object.remove_video()
 
     _function_end(pu)
 

--- a/movie/utils/files.py
+++ b/movie/utils/files.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+from movie.utils import constants
 from movie.utils.logging_config import LOG
 
 
@@ -23,5 +24,34 @@ def remove(file_path: str) -> None:
                 break
         except Exception as e:
             LOG.error(f'Error while removing: {str(e)}')
-            print(err_str)
+            print(str(e))
             break
+
+
+def rename(old_path, new_path):
+    while True:
+        LOG.debug(f'trying to rename: {old_path}')
+        try:
+            os.rename(old_path, new_path)
+            break
+        except OSError as e:
+            if e.winerror == 32:
+                err_str = f'Error accessing file {old_path}: the file is using by another process. Please close the program that is using the file.'
+                LOG.error(err_str)
+                print(err_str)
+                time.sleep(5)
+            else:
+                err_str = f'Error renaming file {old_path}: {e}'
+                LOG.error(err_str)
+                print(err_str)
+                break
+        except Exception as e:
+            LOG.error(f'Error while renaming file {old_path}: {str(e)}')
+            print(str(e))
+            break
+
+
+def restoring_target_filename_to_source(path_target: str, path_source: str):
+    LOG.debug(constants.LOG_FUNCTION_START.format(name='restoring target filename to source filename'))
+    remove(path_source)
+    rename(path_target, path_source)

--- a/movie/utils/stream.py
+++ b/movie/utils/stream.py
@@ -27,7 +27,7 @@ class Stream:
         return f'{self.index}: ({self.tags.get("language")}) {title}'
     
     @property
-    def type(self):
+    def stream_type(self):
         return self._codec_type
 
 
@@ -42,4 +42,4 @@ def parse_ffprobe_output(output: str) -> list[Stream]:
 
 
 def filter_media_streams(streams: list[Stream]) -> list[Stream]:
-    return [stream for stream in streams if stream.type in ['video', 'audio', 'subtitle']]
+    return [stream for stream in streams if stream.stream_type in ['video', 'audio', 'subtitle']]


### PR DESCRIPTION
- when processing a file, a new file is created with some generated name, which is then renamed to the original file name
- remove old function which remove all videos without _filename_prefix
- rename type property in Stream class to stream_type

- closed https://github.com/bmstu-gaming/movie/issues/34